### PR TITLE
feature:Export callback in UMA instance to express or connect framework

### DIFF
--- a/packages/core/src/core/Uma.ts
+++ b/packages/core/src/core/Uma.ts
@@ -164,8 +164,6 @@ export default class Uma {
         this.use(Router());
 
         if (typeHelper.isFunction(afterLoaded)) await Promise.resolve(Reflect.apply(afterLoaded, this, [this]));
-
-        return this;
     }
 
     // static property start


### PR DESCRIPTION
在koa中callback有这样的描述
> app.callback()
返回适用于 http.createServer() 方法的回调函数来处理请求。你也可以使用此回调函数将 koa 应用程序挂载到 Connect/Express 应用程序中。

所以我们可以通过暴露uma对象中koa的callback用于支持在express项目中部分路由使用Umajs开发。
eg:
```
(async () => {
    const callback = <any> await Uma.callback(options);
    const app = express();
    app.use((req, res, next) => callback(req, res).then(() => {
        if (res.headersSent) return;
        next();
    }));
})();
```