### PR TITLE
feat:Path can modify multiple root paths on the class 

### DIFF
--- a/packages/app/src/controller/index.controller.ts
+++ b/packages/app/src/controller/index.controller.ts
@@ -14,7 +14,7 @@ export default class Index extends BaseController {
 
     @Service('user')
     userService: UserService;
-
+    
     index() {
         console.log(this.userService.getDefaultUserAge());
 
@@ -32,7 +32,7 @@ export default class Index extends BaseController {
             frameName: this.testService.returnFrameName(),
         });
     }
-
+    @Path()
     @Path('/home')
     home() {
         this.setHeader('clientType','PC');

--- a/packages/app/src/controller/template.controller.ts
+++ b/packages/app/src/controller/template.controller.ts
@@ -3,6 +3,7 @@ import { Post } from '@umajs/path';
 import { AgeCheck } from '../decorator/AgeCheck';
 import { Result } from '../plugins/test/index';
 
+@Path('/template')
 @Path('/tpl')
 export default class Template extends BaseController {
     @Path({ method: RequestMethod.GET })

--- a/packages/core/src/info/controllerInfo.ts
+++ b/packages/core/src/info/controllerInfo.ts
@@ -35,8 +35,10 @@ export default class {
             clazzInfo.name = clazzName;
         }
 
-        // if (clazzName) clazzInfo.name = clazzName;
-        if (rootPath) clazzInfo.path = rootPath;
+        if (rootPath) {
+            clazzInfo.path = clazzInfo.path || [];
+            clazzInfo.path.push(rootPath);
+        }
 
         if (methodName) {
             const methodMap: Map<string, TMethodInfo> = clazzInfo.methodMap || new Map();

--- a/packages/core/src/types/TControllerInfo.ts
+++ b/packages/core/src/types/TControllerInfo.ts
@@ -20,7 +20,7 @@ export type TMethodInfo = {
 
 export type TControllerInfo = {
     name?: string // 文件名
-    path?: string // 路径
+    path?: Array<string> // 路径
     clazz?: Function // class 对象
     methodMap?: Map<string, TMethodInfo> // 方法map
 }

--- a/packages/router/src/helper.ts
+++ b/packages/router/src/helper.ts
@@ -1,7 +1,12 @@
 /**
- * replace tail '/'
+ * replace tail '//' to '/'
+ * replace tail '/home/' to '/home'
+ * replace tail '//home' to /home'
+ * replace tail '//home//index/' to '/home/index'
  * @param url string
  */
 export function replaceTailSlash(url: string) {
+    url = url.replace(/\/{2,}/g, '/');
+
     return url.endsWith('/') ? url.slice(0, -1) : url;
 }

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -14,7 +14,7 @@ export const Router = () => {
 
     // go through contollerInfo，and init each router map
     for (const controllerInfo of Uma.controllersInfo) {
-        const { name: clazzName, path: rootPath = '', clazz } = controllerInfo;
+        const { name: clazzName, path: rootPath = ['/'], clazz } = controllerInfo;
         const methodMap: Map<string, TMethodInfo> = controllerInfo.methodMap || new Map();
 
         const decoratorMethodNameArr: string[] = [...methodMap.values()].map((m) => m.name);
@@ -36,29 +36,31 @@ export const Router = () => {
             paths.forEach(({ path: p, methodTypes }) => {
                 if (!p) return;
 
-                // 路由访问地址为class中的Path修饰地址 + method的Path修饰地址
-                const routePath = replaceTailSlash(rootPath + p) || '/';
+                rootPath.forEach((root:string) => {
+                    // 路由访问地址为class中的Path修饰地址 + method的Path修饰地址
+                    const routePath = replaceTailSlash(root + p) || '/';
 
-                if (!ALLROUTE.includes(String(routePath))) {
-                    console.log(`[${methodTypes ? methodTypes.join() : 'ALL'}]:${routePath} ==> ${clazzName}.${methodName}`);
-                    ALLROUTE.push(routePath);
-                } else {
+                    if (!ALLROUTE.includes(String(routePath))) {
+                        console.log(`[${methodTypes ? methodTypes.join() : 'ALL'}]:${routePath} ==> ${clazzName}.${methodName}`);
+                        ALLROUTE.push(routePath);
+                    } else {
                     // 注册路由重复
-                    console.error(`${routePath} ==> ${clazzName}.${methodName} has been registered.
+                        console.error(`${routePath} ==> ${clazzName}.${methodName} has been registered.
                     Recommended use the Path decorator to annotate the ${clazzName}.controller.ts`);
 
-                    return;
-                }
+                        return;
+                    }
 
-                // 如果method设置的Path中有:/(被认定为正则匹配路由，否则为静态路由
-                if (p.indexOf(':') > -1 || p.indexOf('(') > -1) {
-                    const keys: pathToRegexp.Key[] = [];
-                    const pathReg = pathToRegexp(routePath, keys);
+                    // 如果method设置的Path中有:/(被认定为正则匹配路由，否则为静态路由
+                    if (p.indexOf(':') > -1 || p.indexOf('(') > -1) {
+                        const keys: pathToRegexp.Key[] = [];
+                        const pathReg = pathToRegexp(routePath, keys);
 
-                    RegexpRouterMap.set(pathReg, { ...pathInfo, keys, routePath, methodTypes });
-                } else {
-                    StaticRouterMap.set(routePath, { ...pathInfo, methodTypes });
-                }
+                        RegexpRouterMap.set(pathReg, { ...pathInfo, keys, routePath, methodTypes });
+                    } else {
+                        StaticRouterMap.set(routePath, { ...pathInfo, methodTypes });
+                    }
+                });
             });
         }
 


### PR DESCRIPTION
- feat:Path can modify multiple root paths on the class
```ts
@Path('/template')
@Path('/tpl')
export default class Template extends BaseController {
    @Path({ method: RequestMethod.GET })
    home() {
        return Result.send('this is home router in template1');
    }
}
```
- fix:when used `@path('/')` decorator on the class ,method router don't work with `@Path('/test')`
```ts
@Path('/')
export default class Template extends BaseController {
    @Path('/test')
    home() {
        return Result.send('this is home router in template1');
    }
}

```
